### PR TITLE
Solved problem with blog's paths

### DIFF
--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -7,7 +7,7 @@ import PostCard from '../components/PostCard'
 const PaginationLink = props => {
   if (!props.test) {
     return (
-      <Link to={`/blog${props.url}`} className='button is-rounded'>
+      <Link to={`/blog/${props.url}`} className='button is-rounded'>
         {props.text}
       </Link>
     )


### PR DESCRIPTION
When we had more than one article, the "Next page" wasn't working fine because of a missing slash.