### PR TITLE
Fix for CMS Blog Template not rendering markdown.

### DIFF
--- a/src/cms/preview-templates/ArticlePreview.js
+++ b/src/cms/preview-templates/ArticlePreview.js
@@ -4,14 +4,20 @@ import ArticleTemplate from '../../components/ArticleTemplate'
 
 const ArticlePreview = ({entry, widgetFor}) => {
   return (
-    <ArticleTemplate
-      content={widgetFor('body')}
-      cover={entry.getIn(['data', 'cover'])}
-      meta_title={entry.getIn(['data', 'meta_title'])}
-      meta_desc={entry.getIn(['data', 'meta_description'])}
-      title={entry.getIn(['data', 'title'])}
-      slug={entry.getIn(['data', 'slug'])}
-    />
+    <div className='container content'>
+      <div className='columns'>
+        <div className='column is-10 is-offset-1'>    
+          <ArticleTemplate
+            content={widgetFor('body')}
+            cover={entry.getIn(['data', 'cover'])}
+            meta_title={entry.getIn(['data', 'meta_title'])}
+            meta_desc={entry.getIn(['data', 'meta_description'])}
+            title={entry.getIn(['data', 'title'])}
+            slug={entry.getIn(['data', 'slug'])}
+          />
+        </div>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
There is a bug in the Article Preview for writing and reviewing blog posts.  It will not render markdown correctly because it is not wrapped in a content class div.  I have added the missing divs to this fork. 

Please review and let me know if i have made a mistake.