### PR TITLE
feat: sticky footer

### DIFF
--- a/src/assets/sass/styles.sass
+++ b/src/assets/sass/styles.sass
@@ -3,6 +3,21 @@ $primary-invert: #ffffff
 
 @import "~bulma"
 
+html,
+body,
+#___gatsby,
+#gatsby-focus-wrapper,
+#layout-wrapper
+  height: 100%
+
+#layout-wrapper
+  width: 100%
+  display: flex
+  flex-direction: column
+
+#content-wrapper
+  flex: 1
+
 nav
   border-bottom: lightgray solid 0.1vmin
 

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -18,15 +18,17 @@ class Layout extends Component {
 
   render () {
     return (
-      <>
+      <div id='layout-wrapper'>
         <Helmet>
           <title>{config.siteTitle}</title>
           <meta name='description' content={config.siteDescription} />
         </Helmet>
         <NavBar isActive={this.state.isActive} toggleNavbar={() => this.toggleNavbar()} />
-        <>{this.props.children}</>
+        <div id='content-wrapper'>
+          {this.props.children}
+        </div>
         <Footer />
-      </>
+      </div>
     )
   }
 }


### PR DESCRIPTION
related with: https://github.com/v4iv/gatsby-starter-business/issues/40

It can be also done differently, using just `#layout-wrapper` like so:

```sass
#layout-wrapper
  min-width: calc(100vh - 3.25em) // 3.25em is padding of top navbar 
  display: flex
  flex-direction: column
```

but it depends on bulma's `.navbar` padding-top which seems fragile.